### PR TITLE
Compile with SUPPORT_UCP and PCRE_JAVASCRIPT_COMPAT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "node"
+  - "iojs"
+  - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ node_js:
   - "node"
   - "iojs"
   - "0.10"
+os:
+  - linux
+  - osx

--- a/deps/libpcre/freebsd/config.h
+++ b/deps/libpcre/freebsd/config.h
@@ -323,7 +323,7 @@ sure both macros are undefined; an emulation function will then be used. */
 /* #undef SUPPORT_PCREGREP_JIT */
 
 /* Define to any value to enable support for Unicode properties. */
-/* #undef SUPPORT_UCP */
+#define SUPPORT_UCP /**/
 
 /* Define to any value to enable support for the UTF-8/16/32 Unicode encoding.
    This will work even in an EBCDIC environment, but it is incompatible with

--- a/deps/libpcre/linux/config.h
+++ b/deps/libpcre/linux/config.h
@@ -324,7 +324,7 @@ sure both macros are undefined; an emulation function will then be used. */
 /* #undef SUPPORT_PCREGREP_JIT */
 
 /* Define to any value to enable support for Unicode properties. */
-/* #undef SUPPORT_UCP */
+#define SUPPORT_UCP /**/
 
 /* Define to any value to enable support for the UTF-8/16/32 Unicode encoding.
    This will work even in an EBCDIC environment, but it is incompatible with

--- a/deps/libpcre/osx/config.h
+++ b/deps/libpcre/osx/config.h
@@ -324,7 +324,7 @@ sure both macros are undefined; an emulation function will then be used. */
 /* #undef SUPPORT_PCREGREP_JIT */
 
 /* Define to any value to enable support for Unicode properties. */
-/* #undef SUPPORT_UCP */
+#define SUPPORT_UCP /**/
 
 /* Define to any value to enable support for the UTF-8/16/32 Unicode encoding.
    This will work even in an EBCDIC environment, but it is incompatible with

--- a/deps/libpcre/solaris/config.h
+++ b/deps/libpcre/solaris/config.h
@@ -324,7 +324,7 @@ sure both macros are undefined; an emulation function will then be used. */
 /* #undef SUPPORT_PCREGREP_JIT */
 
 /* Define to any value to enable support for Unicode properties. */
-/* #undef SUPPORT_UCP */
+#define SUPPORT_UCP /**/
 
 /* Define to any value to enable support for the UTF-8/16/32 Unicode encoding.
    This will work even in an EBCDIC environment, but it is incompatible with

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -16,13 +16,11 @@ Filter::Filter(const std::string& name,
     m_Active(active),
     m_FilterLinks(filter_links)
 {
-    pcrecpp::RE_Options options;
-    options.set_utf8(true);
+    this->set_flags(flags);
+    pcrecpp::RE_Options options(this->m_Flags);
     options.set_match_limit(MATCH_LIMIT);
-    this->parse_flags(flags, options);
 
     this->m_RE = new pcrecpp::RE(source, options);
-    this->m_Options = options.all_options();
 }
 
 Filter::Filter(const Filter& copy) : m_Replacement(copy.m_Replacement),
@@ -31,9 +29,10 @@ Filter::Filter(const Filter& copy) : m_Replacement(copy.m_Replacement),
     m_Active(copy.m_Active),
     m_FilterLinks(copy.m_FilterLinks)
 {
-    pcrecpp::RE_Options options(copy.m_Options);
+    this->m_Flags = copy.m_Flags;
+    pcrecpp::RE_Options options(this->m_Flags);
+    options.set_match_limit(MATCH_LIMIT);
     this->m_RE = new pcrecpp::RE(copy.m_RE->pattern(), options);
-    this->m_Options = options.all_options();
 }
 
 Filter& Filter::operator=(const Filter& rhs)
@@ -45,9 +44,10 @@ Filter& Filter::operator=(const Filter& rhs)
     this->m_FilterLinks = rhs.m_FilterLinks;
 
     delete this->m_RE;
-    pcrecpp::RE_Options options(rhs.m_Options);
+    this->m_Flags = rhs.m_Flags;
+    pcrecpp::RE_Options options(this->m_Flags);
+    options.set_match_limit(MATCH_LIMIT);
     this->m_RE = new pcrecpp::RE(rhs.m_RE->pattern(), options);
-    this->m_Options = options.all_options();
     return *this;
 }
 
@@ -69,7 +69,7 @@ const std::string& Filter::source() const
 void Filter::set_source(const std::string& source)
 {
     delete this->m_RE;
-    pcrecpp::RE_Options options(this->m_Options);
+    pcrecpp::RE_Options options(this->m_Flags);
     this->m_RE = new pcrecpp::RE(source, options);
 }
 
@@ -86,19 +86,31 @@ void Filter::set_replacement(const std::string& replacement)
 std::string Filter::flags() const
 {
     std::string flags = "";
-    pcrecpp::RE_Options copy(this->m_Options);
-    if (this->m_Global)   flags.push_back('g');
-    if (copy.caseless())  flags.push_back('i');
-    if (copy.multiline()) flags.push_back('m');
+    if (this->m_Global)                 flags.push_back('g');
+    if (this->m_Flags & PCRE_CASELESS)  flags.push_back('i');
+    if (this->m_Flags & PCRE_MULTILINE) flags.push_back('m');
 
     return flags;
 }
 
 void Filter::set_flags(const std::string& flags)
 {
-    pcrecpp::RE_Options options(this->m_Options);
-    this->parse_flags(flags, options);
-    this->m_Options = options.all_options();
+    this->m_Flags = DEFAULT_FLAGS;
+    for (size_t i = 0; i < flags.size(); i++)
+    {
+        switch (flags[i])
+        {
+            case 'i':
+                this->m_Flags |= PCRE_CASELESS;
+                break;
+            case 'g':
+                this->m_Global = true;
+                break;
+            case 'm':
+                this->m_Flags |= PCRE_MULTILINE;
+                break;
+        }
+    }
 }
 
 bool Filter::active() const
@@ -130,24 +142,5 @@ bool Filter::exec(std::string* input) const
     else
     {
         return this->m_RE->Replace(this->m_Replacement, input);
-    }
-}
-
-void Filter::parse_flags(const std::string& flags, pcrecpp::RE_Options& options)
-{
-    for (size_t i = 0; i < flags.size(); i++)
-    {
-        switch (flags[i])
-        {
-            case 'i':
-                options.set_caseless(true);
-                break;
-            case 'g':
-                this->m_Global = true;
-                break;
-            case 'm':
-                options.set_multiline(true);
-                break;
-        }
     }
 }

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -70,6 +70,7 @@ void Filter::set_source(const std::string& source)
 {
     delete this->m_RE;
     pcrecpp::RE_Options options(this->m_Flags);
+    options.set_match_limit(MATCH_LIMIT);
     this->m_RE = new pcrecpp::RE(source, options);
 }
 

--- a/src/filter.h
+++ b/src/filter.h
@@ -2,6 +2,8 @@
 
 #include <pcrecpp.h>
 
+#define DEFAULT_FLAGS PCRE_UTF8 | PCRE_JAVASCRIPT_COMPAT
+
 class Filter
 {
     public:
@@ -42,7 +44,5 @@ class Filter
         bool m_Global;
         bool m_Active;
         bool m_FilterLinks;
-        int m_Options;
-
-        void parse_flags(const std::string& flags, pcrecpp::RE_Options& options);
+        int m_Flags;
 };

--- a/src/jsfilterlist.cc
+++ b/src/jsfilterlist.cc
@@ -288,7 +288,7 @@ NAN_METHOD(JSFilterList::CheckValidRegex)
 {
     NanScope();
 
-    pcrecpp::RE re(*String::Utf8Value(args[0]->ToString()));
+    pcrecpp::RE re(*String::Utf8Value(args[0]->ToString()), DEFAULT_FLAGS);
     if (re.error().size() > 0)
     {
         return NanThrowError(re.error().c_str());

--- a/test/filterlist.js
+++ b/test/filterlist.js
@@ -65,6 +65,11 @@ var invalid = {
     '(bc': /missing \)/
 };
 
+var valid = [
+    '\\uabcd',
+    '\\p{Mn}'
+];
+
 describe('FilterList', function () {
     describe('constructor', function () {
         it('should accept a valid list in the constructor', function () {
@@ -119,6 +124,12 @@ describe('FilterList', function () {
                 assert.throws(function () {
                     FilterList.checkValidRegex(key);
                 }, invalid[key]);
+            });
+        });
+
+        valid.forEach(function (regex) {
+            it('should not raise an error for ' + regex, function () {
+                FilterList.checkValidRegex(regex);
             });
         });
     });
@@ -447,6 +458,36 @@ describe('FilterList', function () {
             var list = new FilterList(filters);
             var src = '*bold* _italic_ `code`';
             var expect = '<strong>bold</strong> <em>italic</em> <code>code</code>';
+            assert.equal(list.filter(src), expect);
+        });
+
+        it('should filter \\uxxxx correctly', function () {
+            var list = new FilterList([{
+                name: 'unicode',
+                source: '\\u2031',
+                replace: '%',
+                flags: 'g',
+                active: true,
+                filterlinks: false
+            }]);
+
+            var src = '‱';
+            var expect = '%';
+            assert.equal(list.filter(src), expect);
+        });
+
+        it('should filter \\p{} correctly', function () {
+            var list = new FilterList([{
+                name: 'unicode',
+                source: '\\p{M}',
+                replace: '',
+                flags: 'g',
+                active: true,
+                filterlinks: false
+            }]);
+
+            var src = 'x\u20dd';
+            var expect = 'x';
             assert.equal(list.filter(src), expect);
         });
     });


### PR DESCRIPTION
The config header has been modified to define `SUPPORT_UCP`-- this allows the use of unicode character groups such as `\p{M}` (combining marks).  In addition, regular expressions are now compiled with the `PCRE_JAVASCRIPT_COMPAT` flag, which allows the `\uxxxx` notation to be used to match individual unicode codepoints.