### PR TITLE
Change for building on Alpine Linux

### DIFF
--- a/deps/libpcre/linux/config.h
+++ b/deps/libpcre/linux/config.h
@@ -122,7 +122,7 @@ sure both macros are undefined; an emulation function will then be used. */
 /* #undef HAVE_STRTOIMAX */
 
 /* Define to 1 if you have `strtoll'. */
-/* #undef HAVE_STRTOLL */
+#define HAVE_STRTOLL 1
 
 /* Define to 1 if you have `strtoq'. */
 #undef HAVE_STRTOQ

--- a/deps/libpcre/linux/config.h
+++ b/deps/libpcre/linux/config.h
@@ -125,7 +125,7 @@ sure both macros are undefined; an emulation function will then be used. */
 /* #undef HAVE_STRTOLL */
 
 /* Define to 1 if you have `strtoq'. */
-#define HAVE_STRTOQ 1
+#define HAVE_STRTOQ 0
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #define HAVE_SYS_STAT_H 1

--- a/deps/libpcre/linux/config.h
+++ b/deps/libpcre/linux/config.h
@@ -125,7 +125,7 @@ sure both macros are undefined; an emulation function will then be used. */
 /* #undef HAVE_STRTOLL */
 
 /* Define to 1 if you have `strtoq'. */
-#define HAVE_STRTOQ 0
+#undef HAVE_STRTOQ
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #define HAVE_SYS_STAT_H 1


### PR DESCRIPTION
You may want to put this on a separate branch. This allows pcre to build on Alpine Linux. This is required for dockerizing cytube with an Alpine Linux base. Ideally you would run ./configure everytime you build but this causes less changes.